### PR TITLE
1.3版本代码，增加从var包中读取MMD数据的支持

### DIFF
--- a/src/Player/Audio/AudioPlayHelper.UI.cs
+++ b/src/Player/Audio/AudioPlayHelper.UI.cs
@@ -153,19 +153,6 @@ namespace mmd2timeline
             _chooser.choices = choices.ToArray().ToList();
             _chooser.displayChoices = displayChoices.ToArray().ToList();
 
-            LogUtil.Log("choices-----");
-
-            foreach (var c in choices)
-            {
-                LogUtil.Log(c);
-            }
-            LogUtil.Log("displayChoices-------");
-
-            foreach (var c in displayChoices)
-            {
-                LogUtil.Log(c);
-            }
-
             if (string.IsNullOrEmpty(choice))
             {
                 choice = _chooser.defaultVal;

--- a/src/Player/Audio/AudioPlayHelper.UI.cs
+++ b/src/Player/Audio/AudioPlayHelper.UI.cs
@@ -153,6 +153,19 @@ namespace mmd2timeline
             _chooser.choices = choices.ToArray().ToList();
             _chooser.displayChoices = displayChoices.ToArray().ToList();
 
+            LogUtil.Log("choices-----");
+
+            foreach (var c in choices)
+            {
+                LogUtil.Log(c);
+            }
+            LogUtil.Log("displayChoices-------");
+
+            foreach (var c in displayChoices)
+            {
+                LogUtil.Log(c);
+            }
+
             if (string.IsNullOrEmpty(choice))
             {
                 choice = _chooser.defaultVal;

--- a/src/Player/Audio/AudioPlayHelper.cs
+++ b/src/Player/Audio/AudioPlayHelper.cs
@@ -1,3 +1,4 @@
+using mmd2timeline.Store;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,6 +10,11 @@ namespace mmd2timeline
     /// </summary>
     internal partial class AudioPlayHelper
     {
+        /// <summary>
+        /// 对应的MMD实体
+        /// </summary>
+        MMDEntity _MMDEntity = null;
+
         /// <summary>
         /// 音频设定
         /// </summary>
@@ -170,9 +176,11 @@ namespace mmd2timeline
         /// </summary>
         /// <param name="start"></param>
         /// <param name="end"></param>
-        internal void InitPlay(AudioSetting settings, List<string> choices, List<string> displayChoices)
+        internal void InitPlay(MMDEntity entity, List<string> choices, List<string> displayChoices)
         {
-            _AudioSetting = settings;
+            _MMDEntity = entity;
+
+            _AudioSetting = _MMDEntity.AudioSetting;
 
             // 记录设定中的延迟值
             _delay = _AudioSetting.TimeDelay;
@@ -184,7 +192,7 @@ namespace mmd2timeline
                 SetTimeDelay(_delay);
             }
 
-            SetChooser(displayChoices, choices, settings?.AudioPath);
+            SetChooser(displayChoices, choices, _AudioSetting?.AudioPath);
         }
 
         /// <summary>
@@ -285,7 +293,30 @@ namespace mmd2timeline
                 audioPath = null;
             }
 
-            AudioCliper.LoadAudio(audioPath);
+            AudioCliper.LoadAudio(GetRealPath(audioPath));
+        }
+
+        /// <summary>
+        /// 获取真实路径
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        private string GetRealPath(string path)
+        {
+            // 检查数据是否在VAR包中，如果是，更改路径
+            if (_MMDEntity != null && _MMDEntity.InPackage && !string.IsNullOrEmpty(path))
+            {
+                if (path.StartsWith("SELF"))
+                {
+                    path = path.Replace("SELF", _MMDEntity.PackageName);
+                }
+                else
+                {
+                    path = _MMDEntity.PackageName + ":/" + path;
+                }
+            }
+
+            return path;
         }
 
         /// <summary>

--- a/src/Player/Audio/AudioPlayHelper.cs
+++ b/src/Player/Audio/AudioPlayHelper.cs
@@ -21,9 +21,30 @@ namespace mmd2timeline
         /// <summary>
         /// 音源
         /// </summary>
-        public AudioSource _AudioSource => _AudioSource2 ?? audioSourceFallback;
-        private AudioSource audioSourceFallback;
-        public AudioSource _AudioSource2;
+        //public AudioSource _AudioSource => _AudioSource2 ?? audioSourceFallback;
+        //private AudioSource audioSourceFallback;
+        //public AudioSource _AudioSource2;
+
+        /// <summary>
+        /// 使用的音源
+        /// </summary>
+        AudioSource _audioSource;
+
+        /// <summary>
+        /// 获取音频源
+        /// </summary>
+        AudioSource _AudioSource
+        {
+            get
+            {
+                return _audioSource ?? _defaultAudioSource;
+            }
+        }
+
+        /// <summary>
+        /// 默认音频源
+        /// </summary>
+        AudioSource _defaultAudioSource = URLAudioClipManager.singleton.testAudioSource;
 
         /// <summary>
         /// 是否正在加载
@@ -125,7 +146,22 @@ namespace mmd2timeline
         private AudioPlayHelper()
         {
             // 初始化音频源
-            audioSourceFallback = URLAudioClipManager.singleton.testAudioSource;
+            //audioSourceFallback = URLAudioClipManager.singleton.testAudioSource;
+        }
+
+        /// <summary>
+        /// 设置音频源
+        /// </summary>
+        /// <param name="atom"></param>
+        internal void SetAudioSource(Atom atom)
+        {
+            // 如果之前有音频源并且在播放，停止播放
+            if (_audioSource != null && _audioSource.isPlaying)
+            {
+                _audioSource.Stop();
+            }
+
+            _audioSource = atom?.GetComponentInChildren<AudioSource>();
         }
 
         /// <summary>
@@ -277,7 +313,8 @@ namespace mmd2timeline
         {
             Clear(true);
 
-            _AudioSource2 = null;
+            _audioSource = null;
+            _defaultAudioSource = null;
             _AudioClipHelper = null;
             _AudioSetting = null;
 

--- a/src/Player/Audio/AudioPlayHelper.cs
+++ b/src/Player/Audio/AudioPlayHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -210,7 +211,7 @@ namespace mmd2timeline
         /// <returns></returns>
         public float GetAudioTime()
         {
-            return _AudioSource.time;
+            return (float)Math.Ceiling(_AudioSource.time * 100f) / 100f;
         }
 
         /// <summary>

--- a/src/Player/BaseScript.cs
+++ b/src/Player/BaseScript.cs
@@ -13,7 +13,7 @@ namespace mmd2timeline
     {
         public const string PLUGIN_NAME = "MMD2TimelinePlayer";
 
-        public const string VERSION = "1.3a";
+        public const string VERSION = "1.3";
 
         /// <summary>
         /// 获取插件的版本号

--- a/src/Player/BaseScript.cs
+++ b/src/Player/BaseScript.cs
@@ -13,7 +13,7 @@ namespace mmd2timeline
     {
         public const string PLUGIN_NAME = "MMD2TimelinePlayer";
 
-        public const string VERSION = "1.2f1";
+        public const string VERSION = "1.3a";
 
         /// <summary>
         /// 获取插件的版本号

--- a/src/Player/BaseScript.cs
+++ b/src/Player/BaseScript.cs
@@ -13,7 +13,7 @@ namespace mmd2timeline
     {
         public const string PLUGIN_NAME = "MMD2TimelinePlayer";
 
-        public const string VERSION = "1.3f1a";
+        public const string VERSION = "1.3f1";
 
         /// <summary>
         /// 获取插件的版本号

--- a/src/Player/BaseScript.cs
+++ b/src/Player/BaseScript.cs
@@ -13,7 +13,7 @@ namespace mmd2timeline
     {
         public const string PLUGIN_NAME = "MMD2TimelinePlayer";
 
-        public const string VERSION = "1.3";
+        public const string VERSION = "1.3f1a";
 
         /// <summary>
         /// 获取插件的版本号

--- a/src/Player/Camera/CameraHelper.Follow.cs
+++ b/src/Player/Camera/CameraHelper.Follow.cs
@@ -201,6 +201,7 @@ namespace mmd2timeline
                 }
                 else
                 {
+                    // TODO 检查选定的插件是否有附加Embody插件，如果有，则将进行相应处理
                     if (config.UseCameraAtom && _cameraAtom != null)
                     {
                         _cameraAtom.mainController.control.SetPositionAndRotation(position, rotation);
@@ -326,6 +327,33 @@ namespace mmd2timeline
                 SuperController.singleton.disableNavigation = disable;
 
                 OnCameraActivateStatusChanged?.Invoke(this, SuperController.singleton.navigationDisabled);
+
+                // 如果使用镜头原子，则检查镜头原子是否有Embody插件，如果有，则自动进行镜头启用和禁用的处理
+                if (config.UseCameraAtom)
+                {
+                    if (_cameraAtom != null)
+                    {
+                        foreach (string receiverChoice in _cameraAtom.GetStorableIDs())
+                        {
+                            if (receiverChoice.StartsWith("plugin#") && receiverChoice.IndexOf("Embody") > 7)
+                            {
+                                var receiver = _cameraAtom.GetStorableByID(receiverChoice);
+
+                                if (receiver != null)
+                                {
+                                    var activeJSON = receiver.GetBoolJSONParam("Active");
+
+                                    if (activeJSON != null)
+                                    {
+                                        activeJSON.val = SuperController.singleton.navigationDisabled;
+                                    }
+                                }
+
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
 

--- a/src/Player/Camera/CameraHelper.Follow.cs
+++ b/src/Player/Camera/CameraHelper.Follow.cs
@@ -22,6 +22,10 @@ namespace mmd2timeline
         Quaternion _RotationOffset = Quaternion.Euler(0f, 0f, 0f);
         Vector3 _PositionOffset = Vector3.zero;
 
+        Atom _cameraAtom;
+
+        internal void SetCameraAtom(Atom atom) { _cameraAtom = atom; }
+
         /// <summary>
         /// 更新旋转偏移
         /// </summary>
@@ -197,17 +201,24 @@ namespace mmd2timeline
                 }
                 else
                 {
-                    var navigationRigPosition = GetPosition(position, rotation, NavigationRig);
-
-                    if (_positionLock)
+                    if (config.UseCameraAtom && _cameraAtom != null)
                     {
-                        NavigationRig.position = navigationRigPosition;
+                        _cameraAtom.mainController.control.SetPositionAndRotation(position, rotation);
                     }
-
-                    if (!FocusOn(position, rotation.GetUp()) && _rotationLock)
+                    else
                     {
-                        var navigationRigRotation = GetRotation(position, rotation, NavigationRig);
-                        NavigationRig.rotation = navigationRigRotation;
+                        var navigationRigPosition = GetPosition(position, rotation, NavigationRig);
+
+                        if (_positionLock)
+                        {
+                            NavigationRig.position = navigationRigPosition;
+                        }
+
+                        if (!FocusOn(position, rotation.GetUp()) && _rotationLock)
+                        {
+                            var navigationRigRotation = GetRotation(position, rotation, NavigationRig);
+                            NavigationRig.rotation = navigationRigRotation;
+                        }
                     }
 
                     if (config.CameraFOVEnabled)

--- a/src/Player/Camera/CameraHelper.Progress.cs
+++ b/src/Player/Camera/CameraHelper.Progress.cs
@@ -114,8 +114,8 @@ namespace mmd2timeline
 
             // 限制最大帧数，刷新太快可能造成镜头抖动
             // 暂时不开启这个处理，便于底端程序优化镜头动作算法
-            //if (Mathf.Abs(lastProgress - progress) < 1f / 60f)
-            //    return;
+            if (Mathf.Abs(lastProgress - progress) < 1f / 60f)
+                return;
 
             lastProgress = progress;
 

--- a/src/Player/Camera/CameraHelper.Progress.cs
+++ b/src/Player/Camera/CameraHelper.Progress.cs
@@ -114,8 +114,8 @@ namespace mmd2timeline
 
             // 限制最大帧数，刷新太快可能造成镜头抖动
             // 暂时不开启这个处理，便于底端程序优化镜头动作算法
-            if (Mathf.Abs(lastProgress - progress) < 1f / 60f)
-                return;
+            //if (Mathf.Abs(lastProgress - progress) < 1f / 60f)
+            //    return;
 
             lastProgress = progress;
 

--- a/src/Player/Folder/MMDFolderHelper.cs
+++ b/src/Player/Folder/MMDFolderHelper.cs
@@ -42,6 +42,14 @@ namespace mmd2timeline
         /// 默认MMD存储路径
         /// </summary>
         private readonly string _MMDStorePath = FileManagerSecure.GetFullPath("MMD");
+        /// <summary>
+        /// 默认CustomMMD存储路径
+        /// </summary>
+        private readonly string _MMDCustomStorePath = FileManagerSecure.GetFullPath("Custom/MMD");
+        /// <summary>
+        /// VAM根目录
+        /// </summary>
+        private readonly string _VAMRootPath = FileManagerSecure.GetFullPath(".") + "\\";
 
         /// <summary>
         /// MMD目录存储路径
@@ -82,13 +90,17 @@ namespace mmd2timeline
         /// </summary>
         private void Init()
         {
-            if (FileManagerSecure.DirectoryExists(_MMDStorePath))
+            if (FileManagerSecure.DirectoryExists(_MMDCustomStorePath))
+            {
+                _MMDFolder = _MMDCustomStorePath;
+            }
+            else if (FileManagerSecure.DirectoryExists(_MMDStorePath))
             {
                 _MMDFolder = _MMDStorePath;
             }
             else
             {
-                var folder = Application.dataPath.Replace("/", "\\");
+                var folder = FileManagerSecure.GetFullPath("."); ;
                 _MMDFolder = folder;
             }
         }
@@ -102,6 +114,7 @@ namespace mmd2timeline
             try
             {
                 SuperController.singleton.ShowMainHUDAuto();
+                SuperController.singleton.directoryBrowserUI.browseVarFilesAsDirectories = true;
                 SuperController.singleton.directoryBrowserUI.shortCuts = null;
                 SuperController.singleton.directoryBrowserUI.showFiles = true;
                 SuperController.singleton.directoryBrowserUI.fileFormat = FILE_FORMAT;
@@ -157,6 +170,7 @@ namespace mmd2timeline
             try
             {
                 SuperController.singleton.ShowMainHUDAuto();
+                SuperController.singleton.directoryBrowserUI.browseVarFilesAsDirectories = true;
                 SuperController.singleton.directoryBrowserUI.shortCuts = null;
                 SuperController.singleton.directoryBrowserUI.showFiles = true;
                 SuperController.singleton.directoryBrowserUI.fileFormat = FILE_FORMAT;
@@ -303,6 +317,11 @@ namespace mmd2timeline
         {
             // 获取目录中的文件
             var files = FileManagerSecure.GetFiles(path);
+
+            //foreach (var f in files)
+            //{
+            //    LogUtil.Log(FileManagerSecure.NormalizePath(f));
+            //}
 
             if (currentDepth > depth)
             {

--- a/src/Player/Motion/MotionHelper.Progress.cs
+++ b/src/Player/Motion/MotionHelper.Progress.cs
@@ -128,9 +128,9 @@ namespace mmd2timeline
             //}
             //LogUtil.Log($"{progress}");
 
-            // 限制最大帧数，刷新太快可能造成镜头抖动
-            if (Mathf.Abs(lastProgress - progress) < 1f / 60f)
-                return;
+            //// 限制最大帧数，刷新太快可能造成镜头抖动
+            //if (Mathf.Abs(lastProgress - progress) < 1f / 60f)
+            //    return;
 
             lastProgress = progress;
 

--- a/src/Player/Motion/MotionHelper.cs
+++ b/src/Player/Motion/MotionHelper.cs
@@ -16,6 +16,11 @@ namespace mmd2timeline
     internal partial class MotionHelper
     {
         /// <summary>
+        /// 对应的MMD实体
+        /// </summary>
+        MMDEntity _MMDEntity = null;
+
+        /// <summary>
         /// 配置数据
         /// </summary>
         protected static readonly Config config = Config.GetInstance();
@@ -243,8 +248,10 @@ namespace mmd2timeline
         /// <param name="displayChoices"></param>
         /// <param name="choice"></param>
         /// <param name="motion"></param>
-        internal void InitSettings(List<string> choices, List<string> displayChoices, PersonMotion settings)
+        internal void InitSettings(MMDEntity entity, List<string> choices, List<string> displayChoices, PersonMotion settings)
         {
+            _MMDEntity = entity;
+
             _MotionSetting = settings;
 
             _delay = _MotionSetting?.TimeDelay ?? 0f;
@@ -366,6 +373,29 @@ namespace mmd2timeline
         //}
 
         /// <summary>
+        /// 获取真实路径
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        private string GetRealPath(string path)
+        {
+            // 检查数据是否在VAR包中，如果是，更改路径
+            if (_MMDEntity != null && _MMDEntity.InPackage && !string.IsNullOrEmpty(path))
+            {
+                if (path.StartsWith("SELF"))
+                {
+                    path = path.Replace("SELF", _MMDEntity.PackageName);
+                }
+                else
+                {
+                    path = _MMDEntity.PackageName + ":/" + path;
+                }
+            }
+
+            return path;
+        }
+
+        /// <summary>
         /// 导入VMD
         /// </summary>
         /// <param name="path"></param>
@@ -378,6 +408,8 @@ namespace mmd2timeline
                     return;
                 }
 
+                // 检查数据是否在VAR包中，如果是，更改路径
+                path = GetRealPath(path);
                 _MmdPersonGameObject.LoadMotion(path);
 
                 //if (hasAtomInited)

--- a/src/Player/Player.Playlist.cs
+++ b/src/Player/Player.Playlist.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using static UnityEngine.EventSystems.EventTrigger;
 
 namespace mmd2timeline
 {
@@ -123,7 +124,15 @@ namespace mmd2timeline
             _PlaylistChooser.valNoCallback = arg.GUID;
             //}
 
-            LoadMMD(this.Playlist.CurrentMMD);
+            try
+            {
+
+                LoadMMD(this.Playlist.CurrentMMD);
+            }
+            catch (Exception e)
+            {
+                LogUtil.LogError(e);
+            }
         }
 
         /// <summary>

--- a/src/Player/Player.UI.cs
+++ b/src/Player/Player.UI.cs
@@ -69,10 +69,10 @@ namespace mmd2timeline
         /// </summary>
         UIDynamicTwinButton _LoadTwinButton;
 
-        /// <summary>
-        /// 播放速度
-        /// </summary>
-        JSONStorableFloat _PlaySpeedJSON;
+        ///// <summary>
+        ///// 播放速度
+        ///// </summary>
+        //JSONStorableFloat _PlaySpeedJSON;
 
         /// <summary>
         /// 加载提示信息
@@ -144,10 +144,10 @@ namespace mmd2timeline
             RegisterStringChooser(_playModeChooser);
             _PlayUIs.Add(_playModeChooser);
 
-            _PlayUIs.Add(SetupStaticEnumsChooser<ProgressSyncMode>("Sync Mode", ProgressSyncMode.Names, ProgressSyncMode.GetName(ProgressSyncMode.SyncWithAudio), RightSide, m =>
-            {
-                this._ProgressHelper.SyncMode = ProgressSyncMode.GetValue(m);
-            }));
+            //_PlayUIs.Add(SetupStaticEnumsChooser<ProgressSyncMode>("Sync Mode", ProgressSyncMode.Names, ProgressSyncMode.GetName(ProgressSyncMode.SyncWithAudio), RightSide, m =>
+            //{
+            //    this._ProgressHelper.SyncMode = ProgressSyncMode.GetValue(m);
+            //}));
 
             _MMDUIs.Add(_UIPlayButton = Utils.SetupButton(this, Lang.Get("Play"), () => TogglePlaying(), RightSide));
 
@@ -211,23 +211,23 @@ namespace mmd2timeline
             // 创建镜头设置UI
             _CameraHelper.CreateSettingsUI(this, RightSide);
 
-            #region 播放速度UI配置
-            var speedParamName = "Play Speed";
-            _PlaySpeedJSON = new JSONStorableFloat(speedParamName, 1f, 0f, 2f);
-            _PlaySpeedJSON.setCallbackFunction = s =>
-            {
-                // Time.timeScale = s;
-                //_AudioPlayController.SetPlaySpeed(s);
+            //#region 播放速度UI配置
+            //var speedParamName = "Play Speed";
+            //_PlaySpeedJSON = new JSONStorableFloat(speedParamName, 1f, 0f, 2f);
+            //_PlaySpeedJSON.setCallbackFunction = s =>
+            //{
+            //    // Time.timeScale = s;
+            //    //_AudioPlayController.SetPlaySpeed(s);
 
-                _ProgressHelper.SetPlaySpeed(s);
-            };
-            RegisterFloat(_PlaySpeedJSON);
+            //    _ProgressHelper.SetPlaySpeed(s);
+            //};
+            //RegisterFloat(_PlaySpeedJSON);
 
-            var playSpeedSlider = CreateSlider(_PlaySpeedJSON, RightSide);
-            playSpeedSlider.ConfigureQuickButtons(-0.01f, -0.10f, -0.25f, -0.50f, 0.01f, 0.10f, 0.25f, 0.5f);
-            playSpeedSlider.label = Lang.Get(speedParamName);
-            _PlayUIs.Add(_PlaySpeedJSON);
-            #endregion
+            //var playSpeedSlider = CreateSlider(_PlaySpeedJSON, RightSide);
+            //playSpeedSlider.ConfigureQuickButtons(-0.01f, -0.10f, -0.25f, -0.50f, 0.01f, 0.10f, 0.25f, 0.5f);
+            //playSpeedSlider.label = Lang.Get(speedParamName);
+            //_PlayUIs.Add(_PlaySpeedJSON);
+            //#endregion
 
             // 锁定人物位置
             //_MMDUIs.Add(Utils.SetupToggle(this, Lang.Get("Lock Person Position"), config.LockPersonPosition, v => config.LockPersonPosition = v, RightSide));

--- a/src/Player/Player.cs
+++ b/src/Player/Player.cs
@@ -5,6 +5,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using static UnityEngine.EventSystems.EventTrigger;
 
 namespace mmd2timeline
 {

--- a/src/Player/Player.cs
+++ b/src/Player/Player.cs
@@ -1226,8 +1226,6 @@ namespace mmd2timeline
 
             _ProgressHelper.InitSettings(CurrentItem.CurrentSetting);
 
-            LogUtil.Log($"{fileData.AudioPaths.Count}");
-
             // 加载音频设置
             _AudioPlayHelper.InitPlay(CurrentItem, fileData.AudioPaths, fileData.AudioNames);
 

--- a/src/Player/Player.cs
+++ b/src/Player/Player.cs
@@ -152,7 +152,17 @@ namespace mmd2timeline
             RegisterAction(new JSONStorableAction("Toggle Play Mode", () => this.TogglePlayMode()));
 
             RegisterAction(new JSONStorableAction("Reset Person Motion", () => StartCoroutine(ResetAllPersonMotion())));
+
+            _loadPlaylistFile = new JSONStorableString($"Load Playlist File", null);
+            _loadPlaylistFile.setCallbackFunction = v =>
+            {
+                this.Playlist.LoadPlayListPreset(v);
+            };
+
+            RegisterString(_loadPlaylistFile);
         }
+
+        JSONStorableString _loadPlaylistFile;
 
         #region 各种事件处理函数
 

--- a/src/Player/Player.cs
+++ b/src/Player/Player.cs
@@ -208,10 +208,6 @@ namespace mmd2timeline
                     StartCoroutine(InitPersonAtomMotionHelper(atom));
                 }
             }
-            if (atom.type == "AudioSource")
-            {
-                _AudioPlayHelper._AudioSource2 = atom.GetComponentInChildren<AudioSource>();
-            }
         }
         /// <summary>
         /// 原子被移除的接收方法
@@ -915,8 +911,8 @@ namespace mmd2timeline
                     $"A.Progress:{_AudioPlayHelper.GetAudioTime().ToString("0.000")}" +
                     $"\n" +
                     $"lowestControlName:{_MotionHelperGroup.Helpers.FirstOrDefault()?.lowestControlName}" +
-                    $"\n" +
-                    $"AudioSource:{_AudioPlayHelper._AudioSource}" +
+                    //$"\n" +
+                    //$"AudioSource:{_AudioPlayHelper._AudioSource}" +
                     msg);
             }
         }

--- a/src/Player/Player.cs
+++ b/src/Player/Player.cs
@@ -264,7 +264,8 @@ namespace mmd2timeline
             SetMMDCameraProgress(progress);
 
             // 设置音频播放进度
-            if (_ProgressHelper.Speed != 1f // 速度不为1的情况下要同步音频进度
+            if (config.SyncMode != ProgressSyncMode.SyncWithAudio // 同步进度不依据音频
+                || config.PlaySpeed != 1f // 速度不为1的情况下要同步音频进度
                 || hardUpdate // 明确设定硬更新时同步音频进度
                 || _AudioPlayHelper.IsDelay // 启用了音频延迟时需要同步进度
                 || (_AudioPlayHelper.HasAudio && _ProgressHelper.IsPlaying && !_AudioPlayHelper.IsPlaying))// 有音频 但是没有在播放时
@@ -840,7 +841,7 @@ namespace mmd2timeline
             }
 
             // 如果冻结动画或不是活动和启用状态、动作重置中、播放速度为0，进行播放进度冻结后，直接返回
-            if (SuperController.singleton.freezeAnimation || !SuperController.singleton.isActiveAndEnabled || isMotionResetting || !_MotionHelperGroup.AllHasAtomInited() || _PlaySpeedJSON.val <= 0f)
+            if (SuperController.singleton.freezeAnimation || !SuperController.singleton.isActiveAndEnabled || isMotionResetting || !_MotionHelperGroup.AllHasAtomInited() || config.PlaySpeed <= 0f)
             {
                 if (IsPlaying)
                 {
@@ -876,16 +877,16 @@ namespace mmd2timeline
             try
             {
                 // 如果有音频、在播放中，播放速度是1，按照音频进度更新
-                if (_ProgressHelper.SyncMode == ProgressSyncMode.SyncWithAudio &&
-                !_AudioPlayHelper.IsDelay && _AudioPlayHelper.HasAudio && _AudioPlayHelper.IsPlaying && _ProgressHelper.Speed == 1f)
+                if (config.SyncMode == ProgressSyncMode.SyncWithAudio &&
+                !_AudioPlayHelper.IsDelay && _AudioPlayHelper.HasAudio && _AudioPlayHelper.IsPlaying && config.PlaySpeed == 1f)
                 {
                     _ProgressHelper.SetProgress(_AudioPlayHelper.GetAudioTime(), false);
                 }
                 else
                 {
-                    _ProgressHelper.Update();
-                    if (!_AudioPlayHelper.IsDelay && _AudioPlayHelper.HasAudio && _AudioPlayHelper.IsPlaying)
-                        _AudioPlayHelper.SetAudioTime(_ProgressHelper.Progress, false);
+                    _ProgressHelper.Update(config.PlaySpeed);
+                    //if (!_AudioPlayHelper.IsDelay && _AudioPlayHelper.HasAudio && _AudioPlayHelper.IsPlaying)
+                    //    _AudioPlayHelper.SetAudioTime(_ProgressHelper.Progress, false);
                 }
             }
             catch (Exception ex)
@@ -903,7 +904,7 @@ namespace mmd2timeline
         {
             if (config.showDebugInfo)
             {
-                ShowHUDMessage($"Speed:{_ProgressHelper.Speed}" +
+                ShowHUDMessage($"Speed:{config.PlaySpeed}" +
                     $"\n" +
                     $"HasAudio:{_AudioPlayHelper.HasAudio}" +
                     $"\n" +

--- a/src/Player/Player.cs
+++ b/src/Player/Player.cs
@@ -1211,10 +1211,10 @@ namespace mmd2timeline
             {
                 CurrentItem = entity;
 
-                UpdateFavoriteLabel(entity);
+                UpdateFavoriteLabel(CurrentItem);
             }
 
-            var fileData = entity.GetFileData();
+            var fileData = CurrentItem.GetFileData();
 
             // 如果没有内容，停止播放
             if (fileData.DefaultCamera == noneString
@@ -1224,12 +1224,15 @@ namespace mmd2timeline
                 this.StopPlaying();
             }
 
-            _ProgressHelper.InitSettings(entity.CurrentSetting);
+            _ProgressHelper.InitSettings(CurrentItem.CurrentSetting);
+
+            LogUtil.Log($"{fileData.AudioPaths.Count}");
+
             // 加载音频设置
-            LoadAudioSettings(entity.AudioSetting, fileData.AudioPaths, fileData.AudioNames);
+            _AudioPlayHelper.InitPlay(CurrentItem, fileData.AudioPaths, fileData.AudioNames);
 
             // 加载镜头动作
-            LoadCameraSettings(entity.CameraSetting, fileData.MotionPaths, fileData.MotionNames);
+            _CameraHelper.InitPlay(CurrentItem, fileData.MotionPaths, fileData.MotionNames);
 
             //try
             //{
@@ -1329,35 +1332,11 @@ namespace mmd2timeline
                 }
 
                 // 设置人物动作
-                motionHelper?.InitSettings(fileData.MotionPaths, fileData.MotionNames, motion);
+                motionHelper?.InitSettings(CurrentItem, fileData.MotionPaths, fileData.MotionNames, motion);
             }
 
             yield return null;
             atom.collisionEnabled = true;
-        }
-
-        /// <summary>
-        /// 加载音频设置
-        /// </summary>
-        /// <param name="settings"></param>
-        /// <param name="choices"></param>
-        /// <param name="displayChoices"></param>
-        private void LoadAudioSettings(AudioSetting settings, List<string> choices, List<string> displayChoices)
-        {
-            _AudioPlayHelper.InitPlay(settings, choices, displayChoices);
-        }
-
-        /// <summary>
-        /// 加载镜头设置
-        /// </summary>
-        /// <param name="settings"></param>
-        /// <param name="choices"></param>
-        /// <param name="displayChoices"></param>
-        private void LoadCameraSettings(CameraSetting settings, List<string> choices, List<string> displayChoices)
-        {
-            var choice = string.IsNullOrEmpty(settings.CameraPath) ? noneString : settings.CameraPath;
-
-            _CameraHelper.InitPlay(choices, displayChoices, choice, settings);
         }
 
         /// <summary>

--- a/src/Player/Playlist/Playlist.Control.cs
+++ b/src/Player/Playlist/Playlist.Control.cs
@@ -96,7 +96,7 @@ namespace mmd2timeline
             {
                 if (CurrentItem != null)
                 {
-                    return MMDEntity.LoadFromStoreByGUID(CurrentItem.GUID);
+                    return MMDEntity.LoadFromStoreByGUID(CurrentItem.GUID, CurrentItem.PackageName);
                 }
                 else
                 {

--- a/src/Player/Playlist/Playlist.ImportExport.cs
+++ b/src/Player/Playlist/Playlist.ImportExport.cs
@@ -61,7 +61,15 @@ namespace mmd2timeline
         {
             FileManagerSecure.CreateDirectory(PLAYLIST_PATH);
             var shortcuts = FileManagerSecure.GetShortCutsForDirectory(PLAYLIST_PATH);
-            SuperController.singleton.GetMediaPathDialog(HandleLoadPlayListPreset, PLAYLIST_SAVE_EXT, PLAYLIST_PATH, false, true, false, null, false, shortcuts);
+
+            var shortcuts2 = FileManagerSecure.GetShortCutsForDirectory("Saves\\PluginData\\MMD2Timeline");
+
+            foreach (var i in shortcuts2)
+            {
+                shortcuts.Add(i);
+            }
+
+            SuperController.singleton.GetMediaPathDialog(HandleLoadPlayListPreset, PLAYLIST_SAVE_EXT, PLAYLIST_PATH, false, true, false, null, false, shortcuts, true, true);
         }
 
         /// <summary>
@@ -233,7 +241,9 @@ namespace mmd2timeline
                     {
                         var item = list[i].AsObject;
 
-                        this.AddPlayItem(new PlaylistItem().LoadFromJSON<PlaylistItem>(item), notify: false);
+                        var playItem = new PlaylistItem(this.InPackage, this.PackageName).LoadFromJSON<PlaylistItem>(item);
+
+                        this.AddPlayItem(playItem, notify: false);
                     }
 
                     this.Remove("List");
@@ -304,7 +314,9 @@ namespace mmd2timeline
                     {
                         var item = list[i].AsObject;
 
-                        this.AddPlayItem(new PlaylistItem().LoadFromJSON<PlaylistItem>(item), notify: false);
+                        var playItem = new PlaylistItem(this.InPackage, this.PackageName).LoadFromJSON<PlaylistItem>(item);
+
+                        this.AddPlayItem(playItem, notify: false);
 
                         PlayItemImportProgressChanged?.Invoke($"\n\nLoading {fileName} Playlist.\n\n{item["Name"]}", i, total);
                         yield return null;

--- a/src/Player/Playlist/Playlist.ImportExport.cs
+++ b/src/Player/Playlist/Playlist.ImportExport.cs
@@ -69,7 +69,7 @@ namespace mmd2timeline
                 shortcuts.Add(i);
             }
 
-            SuperController.singleton.GetMediaPathDialog(HandleLoadPlayListPreset, PLAYLIST_SAVE_EXT, PLAYLIST_PATH, false, true, false, null, false, shortcuts, true, true);
+            SuperController.singleton.GetMediaPathDialog(LoadPlayListPreset, PLAYLIST_SAVE_EXT, PLAYLIST_PATH, false, true, false, null, false, shortcuts, true, true);
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace mmd2timeline
         /// 从文件加载播放列表
         /// </summary>
         /// <param name="filePath"></param>
-        void HandleLoadPlayListPreset(string filePath)
+        internal void LoadPlayListPreset(string filePath)
         {
             try
             {

--- a/src/Player/Playlist/Playlist.cs
+++ b/src/Player/Playlist/Playlist.cs
@@ -120,6 +120,12 @@ namespace mmd2timeline
             AddTime = DateTime.UtcNow;
         }
 
+        public PlaylistItem(bool inPackage, string packageName)
+        {
+            _inPackage = inPackage;
+            _packageName = packageName;
+        }
+
         /// <summary>
         /// 项目名称
         /// </summary>
@@ -202,6 +208,34 @@ namespace mmd2timeline
                 {
                     this["AddTime"] = value.ToString();
                 }
+            }
+        }
+
+        private bool _inPackage;
+
+        internal override bool InPackage
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.SaveFileName))
+                {
+                    return base.InPackage;
+                }
+                return _inPackage;
+            }
+        }
+
+        private string _packageName;
+
+        internal override string PackageName
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(this.SaveFileName))
+                {
+                    return base.PackageName;
+                }
+                return _packageName;
             }
         }
 

--- a/src/Player/Progress/ProgressHelper.cs
+++ b/src/Player/Progress/ProgressHelper.cs
@@ -9,7 +9,7 @@ namespace mmd2timeline
     /// </summary>
     internal partial class ProgressHelper
     {
-        public int SyncMode = ProgressSyncMode.SyncWithAudio;
+        //public int SyncMode = ProgressSyncMode.SyncWithAudio;
         
         /// <summary>
         /// 播放状态改变的回调委托
@@ -108,14 +108,14 @@ namespace mmd2timeline
         /// MMD设置数据
         /// </summary>
         MMDSetting _mmdSetting;
-        /// <summary>
-        /// 速度值
-        /// </summary>
-        float _speed = 1f;
-        /// <summary>
-        /// 获取当前播放速度
-        /// </summary>
-        public float Speed { get { return _speed; } }
+        ///// <summary>
+        ///// 速度值
+        ///// </summary>
+        //float _speed = 1f;
+        ///// <summary>
+        ///// 获取当前播放速度
+        ///// </summary>
+        //public float Speed { get { return _speed; } }
 
         /// <summary>
         /// 获取是否已经播放到末尾
@@ -221,32 +221,34 @@ namespace mmd2timeline
             }
         }
 
-        /// <summary>
-        /// 设置播放速度
-        /// </summary>
-        /// <param name="speed"></param>
-        public void SetPlaySpeed(float speed)
-        {
-            _speed = speed;
+        ///// <summary>
+        ///// 设置播放速度
+        ///// </summary>
+        ///// <param name="speed"></param>
+        //public void SetPlaySpeed(float speed)
+        //{
+        //    _speed = speed;
 
-            //_AudioSource.pitch = speed;
+        //    //Time.timeScale = speed;
 
-            //if (speed == 1f)
-            //{
-            //    _AudioSource.velocityUpdateMode = AudioVelocityUpdateMode.Auto;
-            //}
-            //else
-            //{
-            //    _AudioSource.velocityUpdateMode = AudioVelocityUpdateMode.Fixed;
-            //}
-        }
+        //    //_AudioSource.pitch = speed;
+
+        //    //if (speed == 1f)
+        //    //{
+        //    //    _AudioSource.velocityUpdateMode = AudioVelocityUpdateMode.Auto;
+        //    //}
+        //    //else
+        //    //{
+        //    //    _AudioSource.velocityUpdateMode = AudioVelocityUpdateMode.Fixed;
+        //    //}
+        //}
 
         /// <summary>
         /// 更新进度数据
         /// </summary>
-        internal void Update()
+        internal void Update(float speed)
         {
-            var deltaTime = Time.deltaTime * _speed;
+            var deltaTime = Time.deltaTime * speed;
 
             var newProgress = _progress + deltaTime;
 
@@ -342,11 +344,11 @@ namespace mmd2timeline
                     // 强制更新时不进行精度调整和帧数限制
                     if (!hardUpdate)
                     {
-                        //// 调整精度
-                        //progress = (float)Math.Ceiling(progress * 10000f) / 10000f;
+                        // 调整精度
+                        progress = (float)Math.Ceiling(progress * 10000f) / 10000f;
                         // 限制最大帧数，刷新太快可能造成镜头抖动
-                        if (Mathf.Abs(_progress - progress) < (1f / 120f))
-                            return;
+                        //if (Mathf.Abs(_progress - progress) < (1f / 120f))
+                        //    return;
                     }
                     // 更新进度变量
                     _progress = progress;

--- a/src/Player/Progress/ProgressHelper.cs
+++ b/src/Player/Progress/ProgressHelper.cs
@@ -345,7 +345,7 @@ namespace mmd2timeline
                     if (!hardUpdate)
                     {
                         // 调整精度
-                        progress = (float)Math.Ceiling(progress * 10000f) / 10000f;
+                        //progress = (float)Math.Ceiling(progress * 10000f) / 10000f;
                         // 限制最大帧数，刷新太快可能造成镜头抖动
                         //if (Mathf.Abs(_progress - progress) < (1f / 120f))
                         //    return;

--- a/src/Player/Settings.UI.cs
+++ b/src/Player/Settings.UI.cs
@@ -173,7 +173,7 @@ namespace mmd2timeline
         {
             var defaultSourceName = noneString;
 
-            var cameraAtomSources = GetSceneAtoms().Where(a => a.type == "Empty").Select(a => a.uid).ToList();
+            var cameraAtomSources = GetSceneAtoms().Where(a => a.type == "Empty" || a.type == "WindowCamera").Select(a => a.uid).ToList();
             cameraAtomSources.Insert(0, defaultSourceName);
 
             if (_cameraAtomChooser == null)
@@ -193,6 +193,30 @@ namespace mmd2timeline
             else
             {
                 _cameraAtomChooser.choices = cameraAtomSources;
+            }
+
+            var defaultChooser = "";
+
+            // 如果镜头原子选定的是默认值
+            if (_cameraAtomChooser.val == _cameraAtomChooser.defaultVal)
+            {
+                // 检查Atom是否有附加EmBody插件，如果有，自动选定它
+
+                foreach (var uid in cameraAtomSources)
+                {
+                    var atom = GetAtomById(uid);
+
+                    if (atom != null && atom.GetStorableIDs().Exists(s => s.StartsWith("plugin#") && s.IndexOf("Embody") > 7))
+                    {
+                        defaultChooser = uid;
+                        break;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(defaultChooser))
+                {
+                    _cameraAtomChooser.val = defaultChooser;
+                }
             }
         }
 

--- a/src/Player/Settings.UI.cs
+++ b/src/Player/Settings.UI.cs
@@ -188,6 +188,7 @@ namespace mmd2timeline
 
                     CameraHelper.GetInstance().SetCameraAtom(target);
                 };
+                RegisterStringChooser(_cameraAtomChooser);
             }
             else
             {
@@ -387,12 +388,14 @@ namespace mmd2timeline
 
             //SetupToggle(config.AutoGazeToWindowCamera, "Auto Gaze to WindowCamera", dft.AutoGazeToWindowCamera, v => config.AutoGazeToWindowCamera = v, RightSide);
 
-            SetupEnumsChooser<CameraControlModes>(CameraControlModes.GetName(config.CameraControlMode), "Camera Control", CameraControlModes.Names, CameraControlModes.GetName(dft.CameraControlMode), RightSide, v =>
+            var cameraControlModeChooser = SetupEnumsChooser<CameraControlModes>(CameraControlModes.GetName(config.CameraControlMode), "Camera Control", CameraControlModes.Names, CameraControlModes.GetName(dft.CameraControlMode), RightSide, v =>
             {
                 config.CameraControlMode = CameraControlModes.GetValue(v);
 
                 RefreshCameraUI();
             });
+
+            RegisterStringChooser(cameraControlModeChooser);
 
             RefreshCameraAtomList();
 

--- a/src/Player/Settings.UI.cs
+++ b/src/Player/Settings.UI.cs
@@ -37,6 +37,7 @@ namespace mmd2timeline
         protected void InitSettingUI()
         {
             InitGeneralSettingUI();
+            InitMotionSettingsUI();
             InitPhysicsMeshUI();
             //InitAutoCorrectUI();
             InitCameraSettingUI();
@@ -113,18 +114,50 @@ namespace mmd2timeline
         /// </summary>
         void InitGeneralSettingUI()
         {
-            //var fpsSlider = Utils.SetupSliderInt(this, "FPS", 60, 0, 300, LeftSide);
+            //var fpsSlider = Utils.SetupSliderInt(this, "FPS", 60, 0, 300, RightSide);
             //fpsSlider.setCallbackFunction = v => UnityEngine.Application.targetFrameRate = (int)v;
 
-            CreateTitleUI("General Settings", LeftSide);
+            CreateTitleUI("General Settings", RightSide);
 
-            //SetupStaticEnumsChooser<MotionEngine>(MotionEngine.GetName(config.MotionEngineMode), "Motion Engine", MotionEngine.Names, MotionEngine.GetName(dft.MotionEngineMode), LeftSide, v => config.MotionEngineMode = MotionEngine.GetValue(v));
+            //SetupStaticEnumsChooser<MotionEngine>(MotionEngine.GetName(config.MotionEngineMode), "Motion Engine", MotionEngine.Names, MotionEngine.GetName(dft.MotionEngineMode), RightSide, v => config.MotionEngineMode = MotionEngine.GetValue(v));
+
+            // 同步模式选择
+            SetupEnumsChooser<ProgressSyncMode>(ProgressSyncMode.GetName(config.SyncMode), "Sync Mode", ProgressSyncMode.Names, ProgressSyncMode.GetName(dft.SyncMode), RightSide, m =>
+            {
+                config.SyncMode = ProgressSyncMode.GetValue(m);
+            });
+
+            #region 播放速度UI配置
+            var speedParamName = "Play Speed";
+            var _PlaySpeedJSON = new JSONStorableFloat(speedParamName, dft.PlaySpeed, 0f, 2f) ;
+            _PlaySpeedJSON.setCallbackFunction = s =>
+            {
+                config.PlaySpeed = s;
+            };
+            RegisterFloat(_PlaySpeedJSON);
+
+            var playSpeedSlider = CreateSlider(_PlaySpeedJSON, RightSide);
+            playSpeedSlider.ConfigureQuickButtons(-0.01f, -0.10f, -0.25f, -0.50f, 0.01f, 0.10f, 0.25f, 0.5f);
+            playSpeedSlider.label = Lang.Get(speedParamName);
+            //_PlayUIs.Add(_PlaySpeedJSON);
+            _StorableFloats.Add(_PlaySpeedJSON);
+            #endregion
 
             SetupSliderFloat(config.Volume, "Play Volume", dft.Volume, 0f, 1f, v =>
             {
                 config.Volume = v;
                 AudioPlayHelper.GetInstance().SetVolume(config.Volume);
-            }, LeftSide, "F4");
+            }, RightSide, "F4");
+
+            Utils.SetupSpacer(this, 10f, RightSide);
+        }
+
+        /// <summary>
+        /// 初始化动作设置UI
+        /// </summary>
+        void InitMotionSettingsUI()
+        {
+            CreateTitleUI("Motion Settings", LeftSide);
 
             SetupSliderFloat(config.GlobalMotionScale, "Generic Motion Scale", dft.GlobalMotionScale, 0.1f, 2f, v =>
             {
@@ -144,7 +177,7 @@ namespace mmd2timeline
             {
                 config.AllJointsSpringPercent = v;
 
-                motionModeChooser.val = Lang.Get(MotionMode.GetName(config.CurrentMotionMode));
+                motionModeChooser.val = MotionMode.GetName(config.CurrentMotionMode);
 
                 SetAllPersonJointsSpringPercent(v);
             }, LeftSide, "F4");
@@ -153,7 +186,7 @@ namespace mmd2timeline
             {
                 config.AllJointsDamperPercent = v;
 
-                motionModeChooser.val = Lang.Get(MotionMode.GetName(config.CurrentMotionMode));
+                motionModeChooser.val = MotionMode.GetName(config.CurrentMotionMode);
 
                 SetAllPersonJointsDamperPercent(v);
             }, LeftSide, "F4");
@@ -164,13 +197,13 @@ namespace mmd2timeline
                 SetAllPersonJointsMaxVelocity(v);
             }, LeftSide, "F4");
 
-            SetupStaticEnumsChooser<PositionState>(PositionState.GetName((int)config.MotionPositionState), "Motion Position State", PositionState.Names, PositionState.GetName((int)dft.MotionPositionState), LeftSide, m =>
+            SetupEnumsChooser<PositionState>(PositionState.GetName((int)config.MotionPositionState), "Motion Position State", PositionState.Names, PositionState.GetName((int)dft.MotionPositionState), LeftSide, m =>
             {
                 config.MotionPositionState = (FreeControllerV3.PositionState)PositionState.GetValue(m);
                 //Player.ResetPersonControllerState();
             });
 
-            SetupStaticEnumsChooser<RotationState>(RotationState.GetName((int)config.MotionRotationState), "Motion Rotation State", RotationState.Names, RotationState.GetName((int)dft.MotionRotationState), LeftSide, m =>
+            SetupEnumsChooser<RotationState>(RotationState.GetName((int)config.MotionRotationState), "Motion Rotation State", RotationState.Names, RotationState.GetName((int)dft.MotionRotationState), LeftSide, m =>
             {
                 config.MotionRotationState = (FreeControllerV3.RotationState)RotationState.GetValue(m);
                 //Player.ResetPersonControllerState();
@@ -190,29 +223,29 @@ namespace mmd2timeline
         /// </summary>
         void InitPhysicsMeshUI()
         {
-            CreateTitleUI("Physics Mesh Settings", RightSide);
+            CreateTitleUI("Physics Mesh Settings", LeftSide);
 
             SetupToggle(config.MouthPhysicsMesh, "Enable Mouth Physics Mesh", dft.MouthPhysicsMesh, (v) =>
             {
                 config.MouthPhysicsMesh = v;
 
                 SetAllPersonPhysicsMesh("MouthPhysicsMesh", v);
-            }, RightSide);
+            }, LeftSide);
 
             SetupToggle(config.BreastPhysicsMesh, "Enable Breast Physics Mesh", dft.BreastPhysicsMesh, (v) =>
             {
                 config.BreastPhysicsMesh = v;
 
                 SetAllPersonPhysicsMesh("BreastPhysicsMesh", v);
-            }, RightSide);
+            }, LeftSide);
 
             SetupToggle(config.LowerPhysicsMesh, "Enable Lower Physics Mesh", dft.LowerPhysicsMesh, (v) =>
             {
                 config.LowerPhysicsMesh = v;
                 SetAllPersonPhysicsMesh("LowerPhysicsMesh", v);
-            }, RightSide);
+            }, LeftSide);
 
-            Utils.SetupSpacer(this, 10f, RightSide);
+            Utils.SetupSpacer(this, 10f, LeftSide);
         }
 
         /// <summary>
@@ -255,7 +288,7 @@ namespace mmd2timeline
 
             //SetupToggle(config.AutoGazeToWindowCamera, "Auto Gaze to WindowCamera", dft.AutoGazeToWindowCamera, v => config.AutoGazeToWindowCamera = v, RightSide);
 
-            SetupStaticEnumsChooser<CameraControlModes>(CameraControlModes.GetName(config.CameraControlMode), "Camera Control Mode", CameraControlModes.Names, CameraControlModes.GetName(dft.CameraControlMode), RightSide, v =>
+            SetupEnumsChooser<CameraControlModes>(CameraControlModes.GetName(config.CameraControlMode), "Camera Control Mode", CameraControlModes.Names, CameraControlModes.GetName(dft.CameraControlMode), RightSide, v =>
             {
                 config.CameraControlMode = CameraControlModes.GetValue(v);
 
@@ -314,7 +347,7 @@ namespace mmd2timeline
             // 是否允许跪姿修正
             SetupToggle(config.EnableKneeingCorrections, "Enable Kneeing Corrections", dft.EnableKneeingCorrections, (v) => config.EnableKneeingCorrections = v, LeftSide);
 
-            SetupStaticEnumsChooser(AutoCorrectHeightMode.GetName(config.AutoFixHeightMode), "Height Correction Mode", AutoCorrectHeightMode.Names, AutoCorrectHeightMode.GetName(dft.AutoFixHeightMode), LeftSide, (StaticEnumsSetCallback<AutoCorrectHeightMode>)(m =>
+            SetupEnumsChooser(AutoCorrectHeightMode.GetName(config.AutoFixHeightMode), "Height Correction Mode", AutoCorrectHeightMode.Names, AutoCorrectHeightMode.GetName(dft.AutoFixHeightMode), LeftSide, (StaticEnumsSetCallback<AutoCorrectHeightMode>)(m =>
             {
                 config.AutoFixHeightMode = AutoCorrectHeightMode.GetValue(m);
                 ShowHeightCorrectionUI();
@@ -463,10 +496,10 @@ namespace mmd2timeline
         /// <param name="rightSide"></param>
         /// <param name="callback"></param>
         /// <returns></returns>
-        private JSONStorableStringChooser SetupStaticEnumsChooser<T>(string value, string label, List<string> names, string defaultValue, bool rightSide, StaticEnumsSetCallback<T> callback)
+        private JSONStorableStringChooser SetupEnumsChooser<T>(string value, string label, List<string> names, string defaultValue, bool rightSide, StaticEnumsSetCallback<T> callback)
         {
             var chooser = SetupStaticEnumsChooser<T>(label, names, defaultValue, rightSide, callback);
-            chooser.val = Lang.Get(value.ToString());
+            chooser.val = value.ToString();
 
             _StorableStrings.Add(chooser);
             return chooser;

--- a/src/Player/Settings.cs
+++ b/src/Player/Settings.cs
@@ -53,6 +53,7 @@ namespace mmd2timeline
 
         public override void OnDestroy()
         {
+            SuperController.singleton.onAtomUIDRenameHandlers -= OnAtomUIDChanged;
             SuperController.singleton.onAtomAddedHandlers -= OnAtomChanged;
             SuperController.singleton.onAtomRemovedHandlers -= OnAtomChanged;
 
@@ -61,6 +62,7 @@ namespace mmd2timeline
 
         public override void OnEnable()
         {
+            SuperController.singleton.onAtomUIDRenameHandlers += OnAtomUIDChanged;
             SuperController.singleton.onAtomAddedHandlers += OnAtomChanged;
             SuperController.singleton.onAtomRemovedHandlers += OnAtomChanged;
 
@@ -69,6 +71,7 @@ namespace mmd2timeline
 
         public override void OnDisable()
         {
+            SuperController.singleton.onAtomUIDRenameHandlers -= OnAtomUIDChanged;
             SuperController.singleton.onAtomAddedHandlers -= OnAtomChanged;
             SuperController.singleton.onAtomRemovedHandlers -= OnAtomChanged;
 

--- a/src/Player/Settings.cs
+++ b/src/Player/Settings.cs
@@ -1,6 +1,6 @@
-using MacGruber;
 using System;
 using System.Linq;
+using static SuperController;
 
 namespace mmd2timeline
 {
@@ -53,7 +53,26 @@ namespace mmd2timeline
 
         public override void OnDestroy()
         {
+            SuperController.singleton.onAtomAddedHandlers -= OnAtomChanged;
+            SuperController.singleton.onAtomRemovedHandlers -= OnAtomChanged;
+
             base.OnDestroy();
+        }
+
+        public override void OnEnable()
+        {
+            SuperController.singleton.onAtomAddedHandlers += OnAtomChanged;
+            SuperController.singleton.onAtomRemovedHandlers += OnAtomChanged;
+
+            base.OnEnable();
+        }
+
+        public override void OnDisable()
+        {
+            SuperController.singleton.onAtomAddedHandlers -= OnAtomChanged;
+            SuperController.singleton.onAtomRemovedHandlers -= OnAtomChanged;
+
+            base.OnDisable();
         }
     }
 }

--- a/src/Player/Store/MMDEntity.Store.cs
+++ b/src/Player/Store/MMDEntity.Store.cs
@@ -52,9 +52,13 @@ namespace mmd2timeline.Store
         {
             try
             {
-                FileManagerSecure.CreateDirectory(this.StorePath);
+                // 只有不在包中的数据才能保存
+                if (!InPackage)
+                {
+                    FileManagerSecure.CreateDirectory(this.StorePath);
 
-                SuperController.singleton.SaveJSON(this, this.StoreFile);
+                    SuperController.singleton.SaveJSON(this, this.StoreFile);
+                }
 
                 NeedSave = false;
             }

--- a/src/Player/Store/MMDEntity.Store.cs
+++ b/src/Player/Store/MMDEntity.Store.cs
@@ -195,25 +195,6 @@ namespace mmd2timeline.Store
                 if (entity != null && !string.IsNullOrEmpty(packageName))
                 {
                     entity.PackageName = packageName;
-
-                    foreach (var setting in entity.Settings)
-                    {
-                        if (setting.AudioSetting.AudioPath.StartsWith("SELF"))
-                        {
-                            setting.AudioSetting.AudioPath = setting.AudioSetting.AudioPath.Replace("SELF", packageName);
-                        }
-                        else
-                        {
-                            setting.AudioSetting.AudioPath = packageName + ":/" + setting.AudioSetting.AudioPath;
-                        }
-
-                        setting.CameraSetting.CameraPath = packageName + ":/" + setting.CameraSetting.CameraPath;
-
-                        foreach (var motion in setting.Motions)
-                        {
-                            motion.Files = motion.Files.Select(f => packageName + ":/" + f).ToList();
-                        }
-                    }
                 }
 
                 return entity;

--- a/src/Player/Store/MMDEntity.cs
+++ b/src/Player/Store/MMDEntity.cs
@@ -176,6 +176,17 @@ namespace mmd2timeline.Store
             }
         }
 
+        string _packageName;
+
+        public string PackageName
+        {
+            get
+            {
+                return _packageName;
+            }
+            set { _packageName = value; }
+        }
+
         /// <summary>
         /// 获取mmd文件数据
         /// </summary>
@@ -200,6 +211,11 @@ namespace mmd2timeline.Store
             {
                 var fullFileName = file.FileName;
                 var fileName = FileManagerSecure.GetFileName(fullFileName);
+
+                if (!string.IsNullOrEmpty(PackageName))
+                {
+                    fullFileName = PackageName + ":/" + fullFileName;
+                }
 
                 if (file.FileType == MMDFileType.Music)
                 {
@@ -537,7 +553,7 @@ namespace mmd2timeline.Store
 
             var to = new string(chars.ToArray());
 
-            return to;
+            return FileManagerSecure.NormalizePath(to);
         }
 
         /// <summary>

--- a/src/Player/Store/MMDEntity.cs
+++ b/src/Player/Store/MMDEntity.cs
@@ -188,6 +188,17 @@ namespace mmd2timeline.Store
         }
 
         /// <summary>
+        /// 获取此MMD实例是否在包中
+        /// </summary>
+        public bool InPackage
+        {
+            get
+            {
+                return !string.IsNullOrEmpty(PackageName);
+            }
+        }
+
+        /// <summary>
         /// 获取mmd文件数据
         /// </summary>
         /// <returns></returns>
@@ -212,7 +223,7 @@ namespace mmd2timeline.Store
                 var fullFileName = file.FileName;
                 var fileName = FileManagerSecure.GetFileName(fullFileName);
 
-                if (!string.IsNullOrEmpty(PackageName))
+                if (InPackage)
                 {
                     fullFileName = PackageName + ":/" + fullFileName;
                 }

--- a/src/Player/Store/MMDEntity.cs
+++ b/src/Player/Store/MMDEntity.cs
@@ -217,16 +217,14 @@ namespace mmd2timeline.Store
             var motions = new List<string>();
             var expressions = new List<string>();
 
+            // 检重
+            var files = this.Files.DistinctBy(f => f.FileName);
+
             // 轮询MMD文件，并对文件自动选择进行预处理
-            foreach (MMDFile file in this.Files)
+            foreach (MMDFile file in files)
             {
                 var fullFileName = file.FileName;
                 var fileName = FileManagerSecure.GetFileName(fullFileName);
-
-                if (InPackage)
-                {
-                    fullFileName = PackageName + ":/" + fullFileName;
-                }
 
                 if (file.FileType == MMDFileType.Music)
                 {

--- a/src/Player/Store/PersonMotion.cs
+++ b/src/Player/Store/PersonMotion.cs
@@ -181,7 +181,7 @@ namespace mmd2timeline.Store
             {
                 if (this.HasKey("MotionScale"))
                     return this["MotionScale"].AsFloat;
-                else return 0.85f;
+                else return 1f;
             }
             set { this["MotionScale"].AsFloat = value; }
         }

--- a/src/Player/Trigger.UI.cs
+++ b/src/Player/Trigger.UI.cs
@@ -726,8 +726,6 @@ namespace mmd2timeline
             {
                 var targetType = _currentTriggerEventAction.TargetType;
 
-                if (targetType == TriggerEventType.Bool) return true;
-
                 switch (targetType)
                 {
                     case TriggerEventType.Bool:

--- a/src/Player/Trigger/TriggerEventHelper.cs
+++ b/src/Player/Trigger/TriggerEventHelper.cs
@@ -166,7 +166,7 @@ namespace mmd2timeline
             if (trigger == null)
                 return;
 
-            // 只有浮点类型的触发器才会传递float值
+            // 触发事件
             trigger.Trigger();
         }
 
@@ -181,7 +181,7 @@ namespace mmd2timeline
             if (trigger == null)
                 return;
 
-            // 只有浮点类型的触发器才会传递float值
+            // 只有字符串类型的触发器才会传递string值
             if (trigger.EventType == TriggerEventType.String)
             {
                 trigger.Trigger(value);
@@ -206,7 +206,7 @@ namespace mmd2timeline
             if (trigger == null)
                 return;
 
-            // 只有浮点类型的触发器才会传递float值
+            // 只有布尔类型的触发器才会传递bool值
             if (trigger.EventType == TriggerEventType.Bool)
             {
                 trigger.Trigger(value);
@@ -255,7 +255,7 @@ namespace mmd2timeline
             if (trigger == null)
                 return;
 
-            // 只有浮点类型的触发器才会传递float值
+            // 只有字符串类型的触发器才会传递string值
             if (trigger.EventType == TriggerEventType.Chooser)
             {
                 trigger.Trigger(value, choices);

--- a/src/Utils/Config.cs
+++ b/src/Utils/Config.cs
@@ -325,6 +325,46 @@ namespace mmd2timeline
 
         #endregion
 
+        /// <summary>
+        /// 进度同步模式
+        /// </summary>
+        public int SyncMode
+        {
+            get
+            {
+                if (this.HasKey("SyncMode"))
+                    return this["SyncMode"].AsInt;
+                else
+                    return ProgressSyncMode.SyncWithAudio;
+            }
+            set
+            {
+                if (this.SyncMode != value)
+                {
+                    this["SyncMode"].AsInt = value;
+                    this.Save();
+                }
+            }
+        }
+        float _playSpeed = 1f;
+        /// <summary>
+        /// 播放速度
+        /// </summary>
+        public float PlaySpeed
+        {
+            get
+            {
+                return _playSpeed;
+            }
+            set
+            {
+                if (value != _playSpeed)
+                {
+                    _playSpeed = value;
+                }
+            }
+        }
+
         #region 动作控制相关的设置
 
         /// <summary>

--- a/src/Utils/Config.cs
+++ b/src/Utils/Config.cs
@@ -291,6 +291,22 @@ namespace mmd2timeline
         }
 
         /// <summary>
+        /// 是否使用窗口摄像机
+        /// </summary>
+        public bool UseWindowCamera
+        {
+            get
+            {
+                if (this.IsInVR)
+                {
+                    return false;
+                }
+
+                return UseOriginalCamera || (this.SyncWindowCamera);
+            }
+        }
+
+        /// <summary>
         /// 获取是否使用原始相机
         /// </summary>
         internal bool UseOriginalCamera
@@ -298,6 +314,28 @@ namespace mmd2timeline
             get
             {
                 return this.CameraControlMode == CameraControlModes.Original;
+            }
+        }
+
+        /// <summary>
+        /// 同步WindowCarmera
+        /// </summary>
+        public bool SyncWindowCamera
+        {
+            get
+            {
+                return this.CameraControlMode == CameraControlModes.WindowCamera;
+            }
+        }
+
+        /// <summary>
+        /// 是否将镜头数据赋予原子
+        /// </summary>
+        public bool UseCameraAtom
+        {
+            get
+            {
+                return this.CameraControlMode == CameraControlModes.Atom;
             }
         }
 
@@ -993,45 +1031,6 @@ namespace mmd2timeline
         //        }
         //    }
         //}
-
-        /// <summary>
-        /// 是否使用窗口摄像机
-        /// </summary>
-        public bool UseWindowCamera
-        {
-            get
-            {
-                if (this.IsInVR)
-                {
-                    return false;
-                }
-
-                return UseOriginalCamera || (this.SyncWindowCamera);
-            }
-        }
-
-        /// <summary>
-        /// 同步WindowCarmera
-        /// </summary>
-        public bool SyncWindowCamera
-        {
-            get
-            {
-                if (this.HasKey("SyncWindowCamera"))
-                {
-                    return this["SyncWindowCamera"].AsBool;
-                }
-                else return false;
-            }
-            set
-            {
-                if (this.SyncWindowCamera != value)
-                {
-                    this["SyncWindowCamera"].AsBool = value;
-                    this.Save();
-                }
-            }
-        }
 
         #region 快捷键管理
         /// <summary>

--- a/src/Utils/Config.cs
+++ b/src/Utils/Config.cs
@@ -456,7 +456,7 @@ namespace mmd2timeline
             {
                 if (this.HasKey("GlobalMotionScale"))
                     return this["GlobalMotionScale"].AsFloat;
-                else return 1f;
+                else return .85f;
             }
             set
             {

--- a/src/Utils/Enums.cs
+++ b/src/Utils/Enums.cs
@@ -157,11 +157,13 @@ namespace mmd2timeline
     {
         public const int Original = 0;
         public const int Custom = 1;
+        public const int WindowCamera = 2;
+        public const int Atom = 3;
 
         /// <summary>
         /// 初始化枚举类
         /// </summary>
-        private static EnumClass enums = new EnumClass("Original", "Custom");
+        private static EnumClass enums = new EnumClass("Original", "Custom", "WindowCamera", "Atom");
 
         /// <summary>
         /// 获取名称列表
@@ -329,7 +331,7 @@ namespace mmd2timeline
         }
     }
 
-    
+
     /// <summary>
     /// 同步模式
     /// </summary>

--- a/src/Utils/Lang.cs
+++ b/src/Utils/Lang.cs
@@ -287,7 +287,7 @@ namespace mmd2timeline
             this["Play Mode"] = "播放模式";
             this["Sync Mode"] = "同步模式";
             this["SyncWithGame"] = "与游戏帧同步";
-            this["SyncWithAudio"] = "与音乐同步";
+            this["SyncWithAudio"] = "与音频同步";
             this["Playlist"] = "播放列表";
             this["Load Favorite"] = "加载收藏";
             this["Load All"] = "加载所有";

--- a/src/Utils/Lang.cs
+++ b/src/Utils/Lang.cs
@@ -497,6 +497,8 @@ namespace mmd2timeline
             this["Motion 4"] = "动作 4";
             this["Settings"] = "设置";
             this["Action"] = "动作";
+            this["Audio Settings"] = "音频设置";
+            this["Audio Source"] = "音频源";
         }
     }
 }

--- a/src/Utils/MSJSONClass.cs
+++ b/src/Utils/MSJSONClass.cs
@@ -1,4 +1,5 @@
-﻿using MVR.FileManagementSecure;
+﻿using MVR.FileManagement;
+using MVR.FileManagementSecure;
 using SimpleJSON;
 using System;
 using System.Text;
@@ -11,7 +12,34 @@ namespace mmd2timeline
     /// <remarks>主要提供文件保存/加载相关的便利方法</remarks>
     internal abstract class MSJSONClass : JSONClass
     {
-        private string _SaveFileName;
+        /// <summary>
+        /// 指示数据文件是否在压缩包中
+        /// </summary>
+        internal virtual bool InPackage
+        {
+            get
+            {
+                return FileManagerSecure.IsFileInPackage(_SaveFileName);
+            }
+        }
+
+        /// <summary>
+        /// 获取所在的包名称
+        /// </summary>
+        internal virtual string PackageName
+        {
+            get
+            {
+                if (InPackage)
+                {
+                    return _SaveFileName.Split(':')[0];
+                }
+
+                return null;
+            }
+        }
+
+        private string _SaveFileName = null;
         /// <summary>
         /// 获取或设置保存文件的名称
         /// </summary>
@@ -21,14 +49,17 @@ namespace mmd2timeline
             {
                 if (string.IsNullOrEmpty(_SaveFileName))
                 {
-                    throw new Exception("No value is set for the SaveFileName variable.");
+                    //throw new Exception("No value is set for the SaveFileName variable.");
                 }
 
                 return _SaveFileName;
             }
             set
             {
-                _SaveFileName = value;
+                if (_SaveFileName != value)
+                {
+                    _SaveFileName = value;
+                }
             }
         }
 


### PR DESCRIPTION
1.调整了播放进度的处理机制。现在在Settings界面中提供“同步模式”功能，通过这个功能可以选择按照音频进度还是游戏帧进行进度更新。默认是按照音频进度更新的。使用游戏帧模式可以便于使用第三方插件进行逐帧录制。（此功能在h4sjohnson贡献代码的基础上进行整理改进）
2.增加了音源选择的功能。现在可以选择场景中的其他AudioSource进行音频播放了。（此功能在h4sjohnson贡献代码的基础上进行整理改进）
3.调整了按照音频同步进行播放进度更新时的精度处理，受此影响镜头可能会更稳定一点。
4.调整了镜头控制模式。增加了WindowCamera和Atom两个模式，WindowCamera替代之前的窗口相机选项。Atom选项允许将镜头数据赋予指定空原子，可以使用EmBody绑定到指定空原子上进行镜头跟随处理了，可能镜头会更稳定一点。
5.增加了var包中MMD数据播放的支持。现在可以将MMD数据和播放列表文件打包到var中，并通过播放器进行加载。也就是说可以用var包分享MMD数据了。
